### PR TITLE
Fix failed to parse source map error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,9 @@
     "jsx": "react-jsx",
     "sourceMap": true,
     "declaration": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "inlineSourceMap": true,
+    "inlineSources": true,
   },
   "include": [
     "src"


### PR DESCRIPTION
This fixes the following errors presented during the build:

Failed to parse source map from '.../node_modules/react-router-dom-last-location/src/context/action.ts' file: Error: ENOENT: no such file or directory, open '.../node_modules/react-router-dom-last-location/src/context/action.ts'

Failed to parse source map from '.../node_modules/react-router-dom-last-location/src/context/lastLocation.ts' file: Error: ENOENT: no such file or directory, open '.../node_modules/react-router-dom-last-location/src/context/lastLocation.ts'

Failed to parse source map from '.../node_modules/react-router-dom-last-location/src/context/reducer.ts' file: Error: ENOENT: no such file or directory, open '.../node_modules/react-router-dom-last-location/src/context/reducer.ts'

Failed to parse source map from '.../node_modules/react-router-dom-last-location/src/hoc/withLastLocation.tsx' file: Error: ENOENT: no such file or directory, open '.../node_modules/react-router-dom-last-location/src/hoc/withLastLocation.tsx'

Failed to parse source map from '.../node_modules/react-router-dom-last-location/src/hooks/useLastLocation.ts' file: Error: ENOENT: no such file or directory, open '.../node_modules/react-router-dom-last-location/src/hooks/useLastLocation.ts'

Failed to parse source map from '.../node_modules/react-router-dom-last-location/src/provider/LastLocationProvider.tsx' file: Error: ENOENT: no such file or directory, open '.../node_modules/react-router-dom-last-location/src/provider/LastLocationProvider.tsx'

Failed to parse source map from '.../node_modules/react-router-dom-last-location/src/provider/prevent.ts' file: Error: ENOENT: no such file or directory, open '.../node_modules/react-router-dom-last-location/src/provider/prevent.ts'

